### PR TITLE
add accountName PaymentForm

### DIFF
--- a/prisma/migrations/20240919125947_/migration.sql
+++ b/prisma/migrations/20240919125947_/migration.sql
@@ -681,6 +681,7 @@ CREATE TABLE "PaymentForm" (
     "icNumber" TEXT NOT NULL,
     "bankName" TEXT NOT NULL,
     "bankAccountNumber" TEXT NOT NULL,
+    "bankAccountName" TEXT NOT NULL,
     "bodyMeasurement" TEXT,
     "allergies" TEXT[],
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,7 @@ model PaymentForm {
   userId            String   @unique
   icNumber          String?
   bankName          String?
+  bankAccountName   String?
   bankAccountNumber String?
   bodyMeasurement   String?
   allergies         String[]

--- a/src/controller/campaignController.ts
+++ b/src/controller/campaignController.ts
@@ -134,6 +134,7 @@ const generateAgreement = async (creator: any, campaign: any) => {
       now_date: dayjs().format('ddd LL'),
       creatorAccNumber: creator?.paymentForm.bankAccountNumber,
       creatorBankName: creator?.paymentForm?.bankName,
+      creatorBankAccName: creator?.paymentForm?.bankAccountName,
       agreementFormUrl: campaign?.campaignBrief?.agreementFrom,
       version: 1,
     });

--- a/src/controller/creatorController.ts
+++ b/src/controller/creatorController.ts
@@ -306,7 +306,7 @@ export const getCreatorFullInfoByIdPublic = async (req: Request, res: Response) 
 };
 
 export const updatePaymentForm = async (req: Request, res: Response) => {
-  const { bankName, bankNumber, icPassportNumber }: any = req.body;
+  const { bankName, bankAccName, bankNumber, icPassportNumber }: any = req.body;
 
   try {
     const data = await prisma.paymentForm.upsert({
@@ -316,12 +316,14 @@ export const updatePaymentForm = async (req: Request, res: Response) => {
       update: {
         icNumber: icPassportNumber.toString(),
         bankAccountNumber: bankNumber.toString(),
+        bankAccountName: bankAccName.toString(),
         bankName: bankName?.bank,
       },
       create: {
         user: { connect: { id: req.session.userid } },
         icNumber: icPassportNumber.toString(),
         bankAccountNumber: bankNumber.toString(),
+        bankAccountName: bankAccName.toString(),
         bankName: bankName?.bank,
       },
     });
@@ -336,7 +338,7 @@ export const updateCreatorForm = async (req: Request, res: Response) => {
   //   const { fullName, address, icNumber, bankName, accountNumber } = req.body;
   //   const userId = req.session.userid as string;
 
-  const { fullName, address, icNumber, bankName, accountNumber, userId } = req.body;
+  const { fullName, address, icNumber, bankName, accountName, accountNumber, userId } = req.body;
 
   try {
     const user = await prisma.user.findUnique({
@@ -360,7 +362,7 @@ export const updateCreatorForm = async (req: Request, res: Response) => {
         name: fullName,
         creator: {
           update: {
-            address: address,
+            // address: address,
             isFormCompleted: true,
           },
         },
@@ -372,11 +374,13 @@ export const updateCreatorForm = async (req: Request, res: Response) => {
             update: {
               bankName: bankName,
               bankAccountNumber: accountNumber,
+              bankAccountName: accountName,
               icNumber: icNumber,
             },
             create: {
               bankName: bankName,
               bankAccountNumber: accountNumber,
+              bankAccountName: accountName,
               icNumber: icNumber,
             },
           },

--- a/src/helper/agreementInput.ts
+++ b/src/helper/agreementInput.ts
@@ -17,6 +17,7 @@ export const agreementInput = async (data: {
   agreement_endDate: string;
   now_date: string;
   creatorAccNumber: string;
+  creatorBankAccName: string;
   creatorBankName: string;
   paymentAmount?: number;
   agreementFormUrl: string;
@@ -30,6 +31,7 @@ export const agreementInput = async (data: {
     agreement_endDate,
     now_date,
     creatorAccNumber,
+    creatorBankAccName,
     creatorBankName,
     paymentAmount,
     agreementFormUrl,
@@ -56,6 +58,7 @@ export const agreementInput = async (data: {
       NOW_DATE: now_date,
       CREATOR_NAME: creatorName,
       CREATOR_ACCOUNT_NUMBER: creatorAccNumber,
+      CREATOR_BANK_ACCOUNT_NAME: creatorBankAccName,
       CREATOR_BANK_NAME: creatorBankName,
       CREATOR_PAYMENT: paymentAmount ? paymentAmount.toString() : '200',
       CREATOR_VERSION: `V.${version.toString()}`,

--- a/src/service/invoiceService.ts
+++ b/src/service/invoiceService.ts
@@ -69,6 +69,7 @@ export const createInvoiceService = async (data: any, userId: any, amount: any) 
 
   const bankInfo = {
     bankName: data.user.paymentForm.bankName,
+    accountName: data.user.paymentForm.bankAccountName,
     payTo: data.user.name,
     accountNumber: data.user.paymentForm.bankAccountNumber,
     accountEmail: data.user.email,


### PR DESCRIPTION
The addition of this field allows users to specify the name associated with their bank account,
- Added bankAccountName to the payment form schema.
- Updated the relevant API endpoints to handle the new field.