### PR TITLE
CCD-173 Use videos array for posting links

### DIFF
--- a/src/controller/submissionController.ts
+++ b/src/controller/submissionController.ts
@@ -1192,7 +1192,7 @@ const checkAllSectionsApproved = async (submission: any, currentSection?: string
 };
 
 export const postingSubmission = async (req: Request, res: Response) => {
-  const { submissionId, postingLink } = req.body;
+  const { submissionId, postingLinks } = req.body;
 
   try {
     const submission = await prisma.submission.update({
@@ -1200,7 +1200,8 @@ export const postingSubmission = async (req: Request, res: Response) => {
         id: submissionId,
       },
       data: {
-        content: postingLink,
+        videos: postingLinks.filter((link: string) => link && link.trim() !== ''),
+        content: postingLinks.filter((link: string) => link && link.trim() !== '').join(', '),
         status: 'PENDING_REVIEW',
         submissionDate: dayjs().format(),
       },


### PR DESCRIPTION
This change improves the submission update logic by adding proper filtering of posting links before storing them. The `videos` field now stores an array of valid, non-empty links after filtering out null, undefined, and whitespace-only entries. The `content` field concatenates these filtered links into a comma-separated string for display purposes.