### PR TITLE
feat: validate Instagram and TikTok tokens for submission insights

### DIFF
--- a/src/controller/submissionController.ts
+++ b/src/controller/submissionController.ts
@@ -42,11 +42,30 @@ import {
   handleKanbanSubmission,
   handleSubmissionNotification,
 } from '@services/submissionService';
+import { ensureValidInstagramToken, ensureValidTikTokToken } from '@controllers/socialController';
 
 Ffmpeg.setFfmpegPath(FfmpegPath.path);
 // Ffmpeg.setFfmpegPath(FfmpegProbe.path);
 
 const prisma = new PrismaClient();
+
+const INSTAGRAM_POST_REGEX = /(?:https?:\/\/)?(?:www\.)?instagram\.com\/(?:p|reel|tv)\/[A-Za-z0-9_-]+/i;
+const TIKTOK_POST_REGEX = /(?:https?:\/\/)?(?:www\.)?tiktok\.com\/@[^/]+\/(?:video|photo)\/\d+/i;
+const TIKTOK_MOBILE_REGEX = /(?:https?:\/\/)?(?:vt|vm|m)\.tiktok\.com\/[A-Za-z0-9_-]+/i;
+
+type ReportPlatform = 'Instagram' | 'TikTok' | null;
+
+const getSubmissionReportPlatform = (content?: string | null): ReportPlatform => {
+  if (!content) return null;
+
+  const isInstagramPost = INSTAGRAM_POST_REGEX.test(content);
+  const isTiktokPost = TIKTOK_POST_REGEX.test(content) || TIKTOK_MOBILE_REGEX.test(content);
+
+  if (!isInstagramPost && !isTiktokPost) return null;
+
+  // Keep existing table behavior where Instagram takes precedence if both exist in content.
+  return isInstagramPost ? 'Instagram' : 'TikTok';
+};
 
 /**
  * Extract URLs and schedule initial insight fetch for a submission (non-blocking background task)
@@ -700,6 +719,8 @@ export const adminManageAgreementSubmission = async (req: Request, res: Response
 
 export const getAllSubmissions = async (req: Request, res: Response) => {
   try {
+    const onlyValidSocialInsights = String(req.query.onlyValidSocialInsights || '').toLowerCase() === 'true';
+
     const submissions = await prisma.submission.findMany({
       include: {
         submissionType: {
@@ -759,6 +780,7 @@ export const getAllSubmissions = async (req: Request, res: Response) => {
       type: submission.submissionType.type,
       status: submission.status,
       createdAt: submission.createdAt,
+      updatedAt: submission.updatedAt,
       submissionDate: submission.submissionDate,
       completedAt: submission.completedAt,
       nextsubmission: submission.nextsubmissionDate,
@@ -789,13 +811,100 @@ export const getAllSubmissions = async (req: Request, res: Response) => {
       userId: submission.user.id,
       isInstagramConnected: submission.user.creator?.isFacebookConnected || false,
       isTiktokConnected: submission.user.creator?.isTiktokConnected || false,
+      reportPlatform: getSubmissionReportPlatform(submission.content),
+      isInstagramTokenValid: null as boolean | null,
+      isTiktokTokenValid: null as boolean | null,
       campaign: submission.campaign,
       campaignId: submission.campaignId,
       feedback: submission.feedback,
       approvedByAdmin: submission.admin?.user,
     }));
 
-    return res.status(200).json({ submissions: formattedSubmissions });
+    if (!onlyValidSocialInsights) {
+      return res.status(200).json({ submissions: formattedSubmissions });
+    }
+
+    const instagramTokenValidity = new Map<string, boolean>();
+    const tiktokTokenValidity = new Map<string, boolean>();
+
+    const instagramUserIds = new Set<string>();
+    const tiktokUserIds = new Set<string>();
+
+    formattedSubmissions.forEach((submission) => {
+      if (submission.reportPlatform === 'Instagram' && submission.isInstagramConnected) {
+        instagramUserIds.add(submission.userId);
+      }
+
+      if (submission.reportPlatform === 'TikTok' && submission.isTiktokConnected) {
+        tiktokUserIds.add(submission.userId);
+      }
+    });
+
+    await Promise.all([
+      Promise.all(
+        Array.from(instagramUserIds).map(async (userId) => {
+          try {
+            await ensureValidInstagramToken(userId);
+            instagramTokenValidity.set(userId, true);
+          } catch (error: any) {
+            instagramTokenValidity.set(userId, false);
+            console.warn('[SubmissionReports] Instagram token validation failed', {
+              userId,
+              message: error?.message,
+            });
+          }
+        }),
+      ),
+      Promise.all(
+        Array.from(tiktokUserIds).map(async (userId) => {
+          try {
+            await ensureValidTikTokToken(userId);
+            tiktokTokenValidity.set(userId, true);
+          } catch (error: any) {
+            tiktokTokenValidity.set(userId, false);
+            console.warn('[SubmissionReports] TikTok token validation failed', {
+              userId,
+              message: error?.message,
+            });
+          }
+        }),
+      ),
+    ]);
+
+    const submissionsWithTokenStatus = formattedSubmissions.map((submission) => {
+      let isInstagramTokenValid: boolean | null = null;
+      let isTiktokTokenValid: boolean | null = null;
+
+      if (submission.reportPlatform === 'Instagram') {
+        isInstagramTokenValid = submission.isInstagramConnected
+          ? instagramTokenValidity.get(submission.userId) || false
+          : false;
+      }
+
+      if (submission.reportPlatform === 'TikTok') {
+        isTiktokTokenValid = submission.isTiktokConnected ? tiktokTokenValidity.get(submission.userId) || false : false;
+      }
+
+      return {
+        ...submission,
+        isInstagramTokenValid,
+        isTiktokTokenValid,
+      };
+    });
+
+    const validSubmissions = submissionsWithTokenStatus.filter((submission) => {
+      if (submission.reportPlatform === 'Instagram') {
+        return submission.isInstagramConnected && submission.isInstagramTokenValid;
+      }
+
+      if (submission.reportPlatform === 'TikTok') {
+        return submission.isTiktokConnected && submission.isTiktokTokenValid;
+      }
+
+      return true;
+    });
+
+    return res.status(200).json({ submissions: validSubmissions });
   } catch (error) {
     return res.status(500).json({ message: 'Failed to retrieve submissions', error });
   }


### PR DESCRIPTION
This pull request enhances the `getAllSubmissions` endpoint in `submissionController.ts` to support filtering submissions based on the validity of users' Instagram and TikTok tokens. It introduces logic to detect the platform associated with each submission, checks token validity only when requested, and enriches the returned data with new metadata fields.

**Social platform detection and token validation enhancements:**

* Added logic to detect whether a submission is for Instagram or TikTok by analyzing the submission content using regular expressions, with Instagram taking precedence if both are present (`getSubmissionReportPlatform` and regex constants).
* Introduced two new boolean fields, `isInstagramTokenValid` and `isTiktokTokenValid`, to the submission response, initialized as `null` and later populated based on token validation results.

**Conditional token validation and filtering:**

* When the `onlyValidSocialInsights` query parameter is set to `true`, the endpoint checks the validity of Instagram and TikTok tokens for all relevant users using the `ensureValidInstagramToken` and `ensureValidTikTokToken` functions, and filters submissions to only include those with valid tokens. [[1]](diffhunk://#diff-6628cf62ea5f06ac36c618a881407434c54342f75c4f1319a2051367f7801013R722-R723) [[2]](diffhunk://#diff-6628cf62ea5f06ac36c618a881407434c54342f75c4f1319a2051367f7801013R814-R907)

**Response data improvements:**

* The submission response now includes the `reportPlatform` field (either `'Instagram'`, `'TikTok'`, or `null`) and the `updatedAt` timestamp for each submission. [[1]](diffhunk://#diff-6628cf62ea5f06ac36c618a881407434c54342f75c4f1319a2051367f7801013R783) [[2]](diffhunk://#diff-6628cf62ea5f06ac36c618a881407434c54342f75c4f1319a2051367f7801013R814-R907)