### PR TITLE
fix: encode GCS public URLs for filenames with reserved characters

### DIFF
--- a/src/config/cloudStorage.config.ts
+++ b/src/config/cloudStorage.config.ts
@@ -8,12 +8,23 @@ export const storage = new Storage({
   keyFilename: pathToJSONKey,
 });
 
+export const encodeGcsObjectPath = (objectName: string): string =>
+  objectName.split('/').map(encodeURIComponent).join('/');
+
+export const buildGcsPublicUrl = (bucketName: string, objectName: string, version?: string): string => {
+  const url = `https://storage.googleapis.com/${bucketName}/${encodeGcsObjectPath(objectName)}`;
+
+  return version ? `${url}?v=${encodeURIComponent(version)}` : url;
+};
+
 export const uploadImage = async (tempFilePath: string, fileName: string, folderName: string) => {
   const uploadPromise = new Promise<string>((resolve, reject) => {
+    const destination = `${folderName}/${fileName}`;
+
     storage.bucket(process.env.BUCKET_NAME as string).upload(
       tempFilePath,
       {
-        destination: `${folderName}/${fileName}`,
+        destination,
         gzip: true,
         metadata: {
           cacheControl: 'public, max-age=31536000',
@@ -30,7 +41,7 @@ export const uploadImage = async (tempFilePath: string, fileName: string, folder
           ?.makePublic()
           // eslint-disable-next-line promise/always-return
           .then(() => {
-            const publicURL = `https://storage.googleapis.com/${process.env.BUCKET_NAME}/${folderName}/${fileName}?v=${dayjs().format()}`;
+            const publicURL = buildGcsPublicUrl(process.env.BUCKET_NAME as string, destination, dayjs().format());
             resolve(publicURL);
           })
           .catch((err) => {
@@ -61,7 +72,7 @@ export const uploadProfileImage = async (tempFilePath: string, fileName: string,
     });
 
     // Construct the URL manually
-    const publicUrl = `https://storage.googleapis.com/${process.env.BUCKET_NAME}/${destination}`;
+    const publicUrl = buildGcsPublicUrl(process.env.BUCKET_NAME as string, destination);
 
     return publicUrl;
   } catch (err) {
@@ -72,10 +83,12 @@ export const uploadProfileImage = async (tempFilePath: string, fileName: string,
 
 export const uploadCompanyLogo = async (tempFilePath: string, fileName: string) => {
   const uploadPromise = new Promise<string>((resolve, reject) => {
+    const destination = `companyLogo/${fileName}`;
+
     storage.bucket(process.env.BUCKET_NAME as string).upload(
       tempFilePath,
       {
-        destination: `companyLogo/${fileName}`,
+        destination,
         gzip: true,
         metadata: {
           cacheControl: 'public, max-age=31536000',
@@ -92,7 +105,7 @@ export const uploadCompanyLogo = async (tempFilePath: string, fileName: string) 
           ?.makePublic()
           // eslint-disable-next-line promise/always-return
           .then(() => {
-            const publicURL = `https://storage.googleapis.com/${process.env.BUCKET_NAME}/companyLogo/${fileName}`;
+            const publicURL = buildGcsPublicUrl(process.env.BUCKET_NAME as string, destination);
             resolve(publicURL);
           })
           .catch((err) => {
@@ -190,7 +203,7 @@ export const uploadPitchVideo = async (
 
     return new Promise((resolve, reject) => {
       writeStream.on('finish', () => {
-        const publicURL = `https://storage.googleapis.com/${bucketName}/${destination}?v=${dayjs().format()}`;
+        const publicURL = buildGcsPublicUrl(bucketName, destination, dayjs().format());
         resolve(publicURL);
       });
 
@@ -221,7 +234,7 @@ export const uploadAgreementForm = async (
     // Make the file public
     await file.makePublic();
 
-    const publicURL = file.publicUrl(); // <- This is the correct way
+    const publicURL = buildGcsPublicUrl(bucketName, destination);
 
     return publicURL;
 
@@ -276,7 +289,7 @@ export const uploadAgreementTemplate = async ({
     await file.makePublic();
 
     // Construct the public URL
-    const publicURL = `https://storage.googleapis.com/${bucketName}/${destination}?v=${dayjs().format()}`;
+    const publicURL = buildGcsPublicUrl(bucketName, destination, dayjs().format());
     return publicURL;
   } catch (err) {
     throw new Error(`Error uploading file: ${err.message}`);
@@ -305,7 +318,7 @@ export const uploadDigitalSignature = async ({
     await file.makePublic();
 
     // Construct the public URL
-    const publicURL = `https://storage.googleapis.com/${bucketName}/${destination}?v=${dayjs().format()}`;
+    const publicURL = buildGcsPublicUrl(bucketName, destination, dayjs().format());
     return publicURL;
   } catch (err) {
     throw new Error(`Error uploading file: ${err.message}`);
@@ -334,7 +347,7 @@ export const uploadAttachments = async ({
     await file.makePublic();
 
     // Construct the public URL
-    const publicURL = `https://storage.googleapis.com/${bucketName}/${destination}?v=${dayjs().format()}`;
+    const publicURL = buildGcsPublicUrl(bucketName, destination, dayjs().format());
     return publicURL;
   } catch (err) {
     throw new Error(`Error uploading file: ${err.message}`);
@@ -389,7 +402,7 @@ export const uploadAttachmentStream = async ({
         try {
           await file.makePublic();
           if (progressCallback) progressCallback(100);
-          const publicURL = `https://storage.googleapis.com/${bucketName}/${destination}?v=${dayjs().format()}`;
+          const publicURL = buildGcsPublicUrl(bucketName, destination, dayjs().format());
           resolve(publicURL);
         } catch (err) {
           reject(new Error(`Error finalizing upload: ${err.message}`));

--- a/src/helper/processRawFootages.ts
+++ b/src/helper/processRawFootages.ts
@@ -1,4 +1,4 @@
-import { storage } from '@configs/cloudStorage.config';
+import { buildGcsPublicUrl, storage } from '@configs/cloudStorage.config';
 import amqp from 'amqplib';
 import dayjs from 'dayjs';
 import fse from 'fs-extra';
@@ -43,7 +43,7 @@ import { io } from '@/src/server';
           })
           .on('finish', async () => {
             await blob.makePublic();
-            const publicUrl = `https://storage.googleapis.com/${bucket.name}/${blob.name}`;
+            const publicUrl = buildGcsPublicUrl(bucket.name, blob.name);
             fse.unlinkSync(tempFilePath); // Cleanup temp file
             io.emit('uploadProgress', { name: name, percentage: 100, isDone: true });
           });

--- a/src/helper/processVideo.ts
+++ b/src/helper/processVideo.ts
@@ -1,4 +1,4 @@
-import { storage } from '@configs/cloudStorage.config';
+import { buildGcsPublicUrl, storage } from '@configs/cloudStorage.config';
 import amqp from 'amqplib';
 import dayjs from 'dayjs';
 import fse from 'fs-extra';
@@ -43,7 +43,7 @@ import { io } from '@/src/server';
           })
           .on('finish', async () => {
             await blob.makePublic();
-            const publicUrl = `https://storage.googleapis.com/${bucket.name}/${blob.name}`;
+            const publicUrl = buildGcsPublicUrl(bucket.name, blob.name);
             fse.unlinkSync(tempFilePath); // Cleanup temp file
             io.emit('uploadProgress', { name: name, percentage: 100, isDone: true });
           });

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,7 +29,7 @@ import { PrismaSessionStore } from '@quixo3/prisma-session-store';
 
 import Ffmpeg from 'fluent-ffmpeg';
 import FfmpegPath from '@ffmpeg-installer/ffmpeg';
-import { storage } from '@configs/cloudStorage.config';
+import { buildGcsPublicUrl, storage } from '@configs/cloudStorage.config';
 import dayjs from 'dayjs';
 import passport from 'passport';
 
@@ -593,7 +593,7 @@ app.post('/video', async (req: Request, res: Response) => {
             })
             .on('finish', async () => {
               await blob.makePublic();
-              const publicUrl = `https://storage.googleapis.com/${bucket.name}/${blob.name}`;
+              const publicUrl = buildGcsPublicUrl(bucket.name, blob.name);
               urls.push(publicUrl);
               fse.unlinkSync(tempFilePath); // Cleanup temp file
               resolve();
@@ -634,7 +634,7 @@ app.post('/video', async (req: Request, res: Response) => {
           })
           .on('finish', async () => {
             await blob.makePublic();
-            const publicUrl = `https://storage.googleapis.com/${bucket.name}/${blob.name}`;
+            const publicUrl = buildGcsPublicUrl(bucket.name, blob.name);
             urls.push(publicUrl);
             fse.unlinkSync(tempFilePath); // Cleanup temp file
             resolve();

--- a/src/service/socialMediaService.ts
+++ b/src/service/socialMediaService.ts
@@ -1,4 +1,4 @@
-import { storage } from '@configs/cloudStorage.config';
+import { buildGcsPublicUrl, storage } from '@configs/cloudStorage.config';
 import { encryptToken } from '@helper/encrypt';
 import axios from 'axios';
 import crypto from 'crypto';
@@ -62,7 +62,7 @@ const uploadInstagramThumbnailFromUrl = async (sourceUrl: string, destination: s
 
     await file.makePublic();
 
-    return `https://storage.googleapis.com/${process.env.BUCKET_NAME}/${destination}`;
+    return buildGcsPublicUrl(process.env.BUCKET_NAME, destination);
   } catch (error: any) {
     console.error('[InstagramThumbnailCache] Upload failed', {
       sourceUrl,


### PR DESCRIPTION
## Summary

 This PR fixes an issue where uploaded video files could fail to open if the original filename contained URL-reserved characters like `#`, spaces, or `+`.

## Problem

 Previously, the backend uploaded the file to Google Cloud Storage successfully, but generated the public URL using the raw filename.

Example problematic URL:

 https://storage.googleapis.com/cult_production/VIDEO/cmnzngya302r3qz01nbanr28m_wahed #2.mov

Because # has a special meaning in URLs, the browser treated everything after it as a page fragment instead of part of the filename. As a result, Google Cloud Storage received the wrong object path and returned NoSuchKey.

<img width="1594" height="256" alt="screenshot-004795@2x" src="https://github.com/user-attachments/assets/4687b394-dd09-4db5-9989-4af3634793b7" />

## Fix

The backend now encodes the GCS object path when generating public URLs.

Example fixed URL:

https://storage.googleapis.com/cult_production/VIDEO/cmnzngya302r3qz01nbanr28m_wahed%20%232.mov

The actual uploaded object name in GCS is unchanged. Only the public URL is made browser-safe.